### PR TITLE
Add player comparison visualization

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,6 @@
 from matchup import simulate_matchup
 from data_fetcher import get_team_players
-from utils import summarize_player_stats, extract_player_stats
+from utils import summarize_player_stats
 from visuals import plot_player_comparison
 
 def main():

--- a/visuals.py
+++ b/visuals.py
@@ -1,5 +1,13 @@
 import plotly.graph_objects as go
-from utils import extract_stat
+from utils import extract_stat, extract_player_stats
+
+__all__ = [
+    "plot_team_comparison",
+    "plot_rosters",
+    "plot_win_probabilities",
+    "plot_headlines_and_players",
+    "plot_player_comparison",
+]
 
 def plot_team_comparison(team1, team2, stats1, stats2):
     # Extract key stats
@@ -58,7 +66,35 @@ def plot_rosters(team1, players1, team2, players2):
 
     fig.update_layout(title_text=f"{team1} vs {team2} Roster")
     fig.show()
-import plotly.graph_objects as go
+
+
+def plot_player_comparison(players, stat_type, top_n=5):
+    """Create a bar chart comparing top players for a stat type.
+
+    Parameters
+    ----------
+    players : list
+        List of player statistic dictionaries.
+    stat_type : str
+        The statistic type to compare (e.g., ``"rushing.yards"``).
+    top_n : int, optional
+        Number of top players to display, by default 5.
+    """
+
+    stats = extract_player_stats(players, stat_type)
+    # Sort players by stat value descending and take top N
+    top_players = sorted(stats, key=lambda x: x[1], reverse=True)[:top_n]
+
+    names = [name for name, _ in top_players]
+    values = [value for _, value in top_players]
+
+    fig = go.Figure(data=[go.Bar(x=names, y=values)])
+    fig.update_layout(
+        title=f"Top {len(names)} Players - {stat_type}",
+        xaxis_title="Player",
+        yaxis_title=stat_type,
+    )
+    fig.show()
 
 def plot_win_probabilities(team1, team2, win_prob1, win_prob2):
     """


### PR DESCRIPTION
## Summary
- add `plot_player_comparison` for comparing top players using Plotly
- expose visualization helpers via `__all__` and clean main imports

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689424598aa08330ae242c3ab27556df