### PR TITLE
Remove duplicate Plotly import in visuals module

### DIFF
--- a/visuals.py
+++ b/visuals.py
@@ -58,7 +58,6 @@ def plot_rosters(team1, players1, team2, players2):
 
     fig.update_layout(title_text=f"{team1} vs {team2} Roster")
     fig.show()
-import plotly.graph_objects as go
 
 def plot_win_probabilities(team1, team2, win_prob1, win_prob2):
     """


### PR DESCRIPTION
## Summary
- clean up visuals module by removing redundant mid-file `plotly.graph_objects` import
- retain single Plotly import at top of file for clarity

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6894245aaad0833098f3947204df398e