### PR TITLE
Prompt for API key when missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ pip install -r requirements.txt
 
 CFB_API_KEY=your_actual_api_key_here
 
+If this variable is not set, the application will prompt you for your key the
+first time it runs.
+
 ### 5. Run the app
 
 python main.py

--- a/main.py
+++ b/main.py
@@ -1,11 +1,15 @@
 from matchup import simulate_matchup
-from data_fetcher import get_team_players
+from data_fetcher import get_team_players, get_api_key
 from utils import summarize_player_stats
 from visuals import plot_player_comparison
 
 def main():
     print("🏈 College Football Matchup Analyzer")
     print("------------------------------------")
+
+    # Prompt for API key if it hasn't been provided via environment variable.
+    # This ensures the user is asked at least once per session.
+    get_api_key()
 
     team1 = input("Enter the first team (e.g., Ohio State): ")
     team2 = input("Enter the second team (e.g., Michigan): ")


### PR DESCRIPTION
## Summary
- prompt interactively for CollegeFootballData API key if not provided in environment
- invoke API key prompt at start of CLI to ensure user is asked once
- document API key prompt behavior in README

## Testing
- `PYTHONPATH=$(pwd) pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68942959e3a48330b8a09720574fd9d0