### PR TITLE
Improve API key prompt

### DIFF
--- a/data_fetcher.py
+++ b/data_fetcher.py
@@ -26,7 +26,11 @@ def get_api_key():
         return ""
 
     # Prompt the user once for their API key
-    api_key = input("Enter your CollegeFootballData API key: ").strip()
+    api_key = input(
+        "Enter your CollegeFootballData API key (free at collegefootballdata.com): "
+    ).strip()
+    if not api_key:
+        print("You can obtain a free key at https://collegefootballdata.com")
     os.environ["CFB_API_KEY"] = api_key
     return api_key
 


### PR DESCRIPTION
## Summary
- clarify CollegeFootballData API key prompt with a note about free keys
- remind users where to obtain a key if they leave the prompt blank

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68942d8ceafc8330bb945bce01ac31d3